### PR TITLE
Avoid NumberFormatException while trying to construct an Integer with @Value annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ A few use case we can use is to decode and encode the string before masking and/
 In case if you need to override the default logging library with the one you choose, just implement `ILogProvider`.
 
 ```java
-LoggerUtil.register(new MyLogProvider());
+LoggerUtil.register(new MyLogProvider()); 
 ```
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ A few use case we can use is to decode and encode the string before masking and/
 #### Extensions
 - ContentSlicerPreProcessor
 
-### LogProvider
+### LogProvider 
 
 In case if you need to override the default logging library with the one you choose, just implement `ILogProvider`.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ eJMask is a JVM-based masking library that provides an easy-to-use API for maski
 
 To get started with eJMask, you'll need to add the eJMask library to your project using your preferred build system, such as Maven or Gradle.
 
-Here's an example of how to use eJMask in your code:
+Here's an example of how to use eJMask in your code: 
 
 ```java
 public class EJMaskExample {

--- a/README.md
+++ b/README.md
@@ -233,14 +233,14 @@ Alternatively you can pull it from the central Maven repositories:
 <dependency>
   <groupId>com.ebay.ejmask</groupId>
   <artifactId>ejmask-bom</artifactId>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
 </dependency>
 ```
 
 ### Using in your Gradle Project.
 
 ```groovy
-compile group: 'com.ebay.ejmask', name: 'ejmask-bom', version: '1.0.1'
+compile group: 'com.ebay.ejmask', name: 'ejmask-bom', version: '1.0.2'
 ```
 
 ## Roadmap

--- a/ejmask-api/pom.xml
+++ b/ejmask-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.ebay.ejmask</groupId>
         <artifactId>ejmask-parent</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
     </parent>
 
     <artifactId>ejmask-api</artifactId>

--- a/ejmask-api/src/main/java/com/ebay/ejmask/api/MaskingPattern.java
+++ b/ejmask-api/src/main/java/com/ebay/ejmask/api/MaskingPattern.java
@@ -109,10 +109,4 @@ public class MaskingPattern implements Comparable<MaskingPattern> {
     public String toString() {
         return "order=" + this.order + ";pattern=" + this.pattern.pattern() + ";replacement=" + this.replacement;
     }
-
-    public int getOrder() { return order; }
-
-    public Pattern getPattern() { return pattern; }
-
-    public String getReplacement() { return replacement; }
 }

--- a/ejmask-api/src/main/java/com/ebay/ejmask/api/MaskingPattern.java
+++ b/ejmask-api/src/main/java/com/ebay/ejmask/api/MaskingPattern.java
@@ -109,4 +109,10 @@ public class MaskingPattern implements Comparable<MaskingPattern> {
     public String toString() {
         return "order=" + this.order + ";pattern=" + this.pattern.pattern() + ";replacement=" + this.replacement;
     }
+
+    public int getOrder() { return order; }
+
+    public Pattern getPattern() { return pattern; }
+
+    public String getReplacement() { return replacement; }
 }

--- a/ejmask-bom/pom.xml
+++ b/ejmask-bom/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.ebay.ejmask</groupId>
         <artifactId>ejmask-parent</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ejmask-core/pom.xml
+++ b/ejmask-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.ebay.ejmask</groupId>
         <artifactId>ejmask-parent</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
     </parent>
 
     <artifactId>ejmask-core</artifactId>

--- a/ejmask-extensions/pom.xml
+++ b/ejmask-extensions/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.ebay.ejmask</groupId>
         <artifactId>ejmask-parent</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
     </parent>
 
     <artifactId>ejmask-extensions</artifactId>

--- a/ejmask-spring/ejmask-spring-autoconfig/pom.xml
+++ b/ejmask-spring/ejmask-spring-autoconfig/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.ebay.ejmask</groupId>
         <artifactId>ejmask-spring</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
     </parent>
 
     <artifactId>ejmask-spring-autoconfig</artifactId>

--- a/ejmask-spring/ejmask-spring-boot/pom.xml
+++ b/ejmask-spring/ejmask-spring-boot/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.ebay.ejmask</groupId>
         <artifactId>ejmask-spring</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
     </parent>
 
     <artifactId>ejmask-spring-boot</artifactId>

--- a/ejmask-spring/ejmask-spring-boot/src/main/java/com/ebay/ejmask/spring/boot/autoconfig/EJMaskAutoConfig.java
+++ b/ejmask-spring/ejmask-spring-boot/src/main/java/com/ebay/ejmask/spring/boot/autoconfig/EJMaskAutoConfig.java
@@ -40,11 +40,11 @@ import javax.inject.Named;
 @ConditionalOnProperty(prefix = "ejmask.", name = "autoconfig", havingValue = "enabled", matchIfMissing = true)
 public class EJMaskAutoConfig {
 
-    @Value("ejmask.processor.content-slicer.priority:50")
+    @Value("${ejmask.processor.content-slicer.priority:50}")
     int contentSlicerPriority;
-    @Value("ejmask.processor.content-slicer.max-size:10000")
+    @Value("${ejmask.processor.content-slicer.max-size:10000}")
     int contentSlicerMaxStringLimit;
-    @Value("ejmask.processor.content-slicer.new-size:4000")
+    @Value("${ejmask.processor.content-slicer.new-size:4000}")
     int contentSlicerNewSize;
 
 

--- a/ejmask-spring/ejmask-spring-core/pom.xml
+++ b/ejmask-spring/ejmask-spring-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.ebay.ejmask</groupId>
         <artifactId>ejmask-spring</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
     </parent>
 
     <artifactId>ejmask-spring-core</artifactId>

--- a/ejmask-spring/pom.xml
+++ b/ejmask-spring/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.ebay.ejmask</groupId>
         <artifactId>ejmask-parent</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
     </parent>
 
     <artifactId>ejmask-spring</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.ebay.ejmask</groupId>
     <artifactId>ejmask-parent</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
 
     <packaging>pom</packaging>
 


### PR DESCRIPTION
## Motivation

Getting NumberFormatException on my spring-boot app while integrating with EJMask library

## Proposed Changes

- changing the format - https://stackoverflow.com/questions/49793547/spring-value-always-gives-an-error-if-property-is-integer
- adding getters for MaskingPattern

## Test Plan
I was able to bring up my spring boot app in local & test masking