### PR TITLE
Getters on MaskingPattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,14 +233,14 @@ Alternatively you can pull it from the central Maven repositories:
 <dependency>
   <groupId>com.ebay.ejmask</groupId>
   <artifactId>ejmask-bom</artifactId>
-  <version>1.0.2</version>
+  <version>1.0.3</version>
 </dependency>
 ```
 
 ### Using in your Gradle Project.
 
 ```groovy
-compile group: 'com.ebay.ejmask', name: 'ejmask-bom', version: '1.0.2'
+compile group: 'com.ebay.ejmask', name: 'ejmask-bom', version: '1.0.3'
 ```
 
 ## Roadmap

--- a/ejmask-api/pom.xml
+++ b/ejmask-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.ebay.ejmask</groupId>
         <artifactId>ejmask-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
     </parent>
 
     <artifactId>ejmask-api</artifactId>

--- a/ejmask-api/src/main/java/com/ebay/ejmask/api/MaskingPattern.java
+++ b/ejmask-api/src/main/java/com/ebay/ejmask/api/MaskingPattern.java
@@ -109,4 +109,25 @@ public class MaskingPattern implements Comparable<MaskingPattern> {
     public String toString() {
         return "order=" + this.order + ";pattern=" + this.pattern.pattern() + ";replacement=" + this.replacement;
     }
+
+    /**
+     * Get the value of order
+     *
+     * @return the value of order
+     */
+    public int getOrder() { return order; }
+
+    /**
+     * Get the value of pattern
+     *
+     * @return the value of pattern
+     */
+    public Pattern getPattern() { return pattern; }
+
+    /**
+     * Get the value of replacement
+     *
+     * @return the value of replacement
+     */
+    public String getReplacement() { return replacement; }
 }

--- a/ejmask-bom/pom.xml
+++ b/ejmask-bom/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.ebay.ejmask</groupId>
         <artifactId>ejmask-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/ejmask-core/pom.xml
+++ b/ejmask-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.ebay.ejmask</groupId>
         <artifactId>ejmask-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
     </parent>
 
     <artifactId>ejmask-core</artifactId>

--- a/ejmask-extensions/pom.xml
+++ b/ejmask-extensions/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.ebay.ejmask</groupId>
         <artifactId>ejmask-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
     </parent>
 
     <artifactId>ejmask-extensions</artifactId>

--- a/ejmask-spring/ejmask-spring-autoconfig/pom.xml
+++ b/ejmask-spring/ejmask-spring-autoconfig/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.ebay.ejmask</groupId>
         <artifactId>ejmask-spring</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
     </parent>
 
     <artifactId>ejmask-spring-autoconfig</artifactId>

--- a/ejmask-spring/ejmask-spring-boot/pom.xml
+++ b/ejmask-spring/ejmask-spring-boot/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.ebay.ejmask</groupId>
         <artifactId>ejmask-spring</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
     </parent>
 
     <artifactId>ejmask-spring-boot</artifactId>

--- a/ejmask-spring/ejmask-spring-core/pom.xml
+++ b/ejmask-spring/ejmask-spring-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.ebay.ejmask</groupId>
         <artifactId>ejmask-spring</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
     </parent>
 
     <artifactId>ejmask-spring-core</artifactId>

--- a/ejmask-spring/pom.xml
+++ b/ejmask-spring/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.ebay.ejmask</groupId>
         <artifactId>ejmask-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
     </parent>
 
     <artifactId>ejmask-spring</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.ebay.ejmask</groupId>
     <artifactId>ejmask-parent</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
 
     <packaging>pom</packaging>
 


### PR DESCRIPTION
## Motivation
Getters on MaskingPattern in order to render the order, pattern, replacement separately on our internal UI to show all the masking patterns available at runtime.

## Proposed Changes
added getters for order, pattern, replacement on MaskingPattern