### PR TITLE
FIX:Non-resolvable parent POM for com.ebay.ejmask:ejmask-bom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 ./reports
 /reports/
 *.iml
+**/.flattened-pom.xml

--- a/README.md
+++ b/README.md
@@ -233,14 +233,14 @@ Alternatively you can pull it from the central Maven repositories:
 <dependency>
   <groupId>com.ebay.ejmask</groupId>
   <artifactId>ejmask-bom</artifactId>
-  <version>2.0.0</version>
+  <version>1.2.1</version>
 </dependency>
 ```
 
 ### Using in your Gradle Project.
 
 ```groovy
-compile group: 'com.ebay.ejmask', name: 'ejmask-bom', version: '2.0.0'
+compile group: 'com.ebay.ejmask', name: 'ejmask-bom', version: '1.2.1'
 ```
 
 ## Roadmap

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" ?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" ?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ebay.ejmask</groupId>
@@ -27,7 +26,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
-        <revision>1.2.0</revision>
+        <revision>1.2.1</revision>
         <changelist></changelist>
     </properties>
 
@@ -121,6 +120,31 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
## Motivation

Post introduction of parameterized tests we were getting unresolved parent pom error.

```
[ERROR] The project com.*.*.*.*:*-*:3.3.0-SNAPSHOT 
    (/Volumes/WorkSpace/*/*/*/*/pom.xml) has 1 error [ERROR] 
    Non-resolvable parent POM for com.ebay.ejmask:ejmask-bom:${revision}${changelist}: T
    he following artifacts could not be resolved: com.ebay.ejmask:ejmask-parent:pom:${revision}${changelist} 
    (absent): Could not transfer artifact com.ebay.ejmask:ejmask-parent:pom:${revision}${changelist} from/to * (https://*.*.*.com/content/repositories/v3debt/):
     status code: 401, reason phrase: Unauthorized (401) @ com.ebay.ejmask:ejmask-bom:${revision}${changelist},
      /Volumes/WorkSpace/*/maven/m2/*/com/ebay/ejmask/ejmask-bom/1.2.0/ejmask-bom-1.2.0.pom, line 4, column 13 -> [Help 2] [ERROR]
```

## Proposed Changes

To avoid issues caused by variables in parent pom we introduced maven pom flattener 

## Test Plan
build with new version 