### PR TITLE
DEV: Spring boot 3.x migration

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -21,10 +21,10 @@ jobs:
       - name: Check out the code
         uses: actions/checkout@v3
 
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: '8'
+          java-version: '17'
           distribution: 'temurin'
           cache: maven
 

--- a/.github/workflows/on_push_build.yml
+++ b/.github/workflows/on_push_build.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: '8'
+          java-version: '17'
           distribution: 'temurin'
           cache: maven
           server-id: ossrh

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ logging easier and simpler without impacting performance.
 
 | JDK Version | Spring Version | Spring Boot Version |
 |-------------|----------------|---------------------|
-| 8           | 5.3.31         | 2.7.18              |
+| 17          | 6.1.11         | 3.2.8               |
 
 ### Getting Started
 

--- a/ejmask-spring/pom.xml
+++ b/ejmask-spring/pom.xml
@@ -20,7 +20,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>2.7.18</version>
+                <version>3.2.8</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
         <revision>2.0.0</revision>
         <changelist>-SNAPSHOT</changelist>
     </properties>
@@ -104,7 +104,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
-            <version>4.11.0</version>
+            <version>5.2.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
-        <revision>1.3.0</revision>
-        <changelist></changelist>
+        <revision>2.0.0</revision>
+        <changelist>-SNAPSHOT</changelist>
     </properties>
 
     <scm>


### PR DESCRIPTION
## Motivation
Spring version 5.x support is limited hence updating the library to support newer version of spring and JDK. 

## Proposed Changes

Updated JDK version to 17 
Updated Spring boot version to 3.x
