### PR TITLE
Fix deployment failure by adding missing POM name and enhancing documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # eJMask `{*:*}`
 
+[![GitHub tag](https://img.shields.io/github/v/release/ebay/ejmask)](https://github.com/eBay/ejmask/releases)
+
 eJMask is a JVM-based masking library that provides an easy-to-use API for masking sensitive data in your Java applications. With eJMask, you can quickly mask sensitive information like personal information, credit card numbers, and more. eJMask library is designed to provide a simple interface to make masking sensitive data sets before logging easier and simpler without impacting performance.
 
 ### Features
@@ -384,13 +386,13 @@ If your application is built on spring boot you can skip the above step by simpl
 
 **Properties**
 
-| property                                   | description                                    | values               | default    |
-|--------------------------------------------|------------------------------------------------|----------------------|------------|
-| `ejmask.autoconfig`                        | Conditionally wire on flat                     | `enabled`,`disabled` | `enabled`  |
-| `ejmask.processor.content-slicer`          | Conditionally wire on content slicer processor | `enabled`,`disabled` | `disabled` |
-| `ejmask.processor.content-slicer.priority` | Content slicer priority                        | integer              | `50`       |
-| `ejmask.processor.content-slicer.max-size` | Content slicer maximum allowed length          | integer              | `10000`    |
-| `ejmask.processor.content-slicer.new-size` | Content slicer maximum new content size.       | integer              | `4000`     |
+| property                                   | description                                                                                                        | values               | default    |
+|--------------------------------------------|--------------------------------------------------------------------------------------------------------------------|----------------------|------------|
+| `ejmask.autoconfig`                        | Enables or disables the entire EJMask auto-configuration. Omit or set to `enabled` to activate.                    | `enabled`,`disabled` | `enabled`  |
+| `ejmask.processor.content-slicer`          | Enables the `ContentSlicerProcessor` bean, which truncates oversized payloads before masking. Disabled by default. | `enabled`,`disabled` | `disabled` |
+| `ejmask.processor.content-slicer.priority` | Execution order of the `ContentSlicerProcessor` relative to other content processors. Lower values run first.      | integer              | `50`       |
+| `ejmask.processor.content-slicer.max-size` | Maximum content length (characters) before the `ContentSlicerProcessor` truncates the payload.                     | integer              | `10000`    |
+| `ejmask.processor.content-slicer.new-size` | Target content length (characters) after truncation. Must be less than `ejmask.processor.content-slicer.max-size`. | integer              | `4000`     |
 
 ### Where can I get the latest release?
 

--- a/ejmask-api/pom.xml
+++ b/ejmask-api/pom.xml
@@ -8,6 +8,7 @@
     </parent>
 
     <artifactId>ejmask-api</artifactId>
+    <name>eJMask API</name>
 
     <dependencies>
         <dependency>

--- a/ejmask-bom/pom.xml
+++ b/ejmask-bom/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>ejmask-bom</artifactId>
+    <name>eJMask BOM</name>
     <packaging>pom</packaging>
 
     <description>

--- a/ejmask-core/pom.xml
+++ b/ejmask-core/pom.xml
@@ -8,6 +8,7 @@
     </parent>
 
     <artifactId>ejmask-core</artifactId>
+    <name>eJMask Core</name>
 
     <dependencies>
         <dependency>

--- a/ejmask-extensions/pom.xml
+++ b/ejmask-extensions/pom.xml
@@ -8,6 +8,7 @@
     </parent>
 
     <artifactId>ejmask-extensions</artifactId>
+    <name>eJMask Extensions</name>
 
     <dependencies>
         <dependency>

--- a/ejmask-spring/ejmask-spring-core/pom.xml
+++ b/ejmask-spring/ejmask-spring-core/pom.xml
@@ -8,6 +8,7 @@
     </parent>
 
     <artifactId>ejmask-spring-core</artifactId>
+    <name>eJMask Spring Core</name>
 
     <dependencies>
         <dependency>

--- a/ejmask-spring/ejmask-spring-starter/pom.xml
+++ b/ejmask-spring/ejmask-spring-starter/pom.xml
@@ -8,6 +8,7 @@
     </parent>
 
     <artifactId>ejmask-spring-starter</artifactId>
+    <name>eJMask Spring Boot Starter</name>
 
     <dependencies>
         <dependency>

--- a/ejmask-spring/ejmask-spring-starter/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/ejmask-spring/ejmask-spring-starter/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -1,0 +1,62 @@
+{
+  "properties": [
+    {
+      "name": "ejmask.autoconfig",
+      "type": "java.lang.String",
+      "description": "Enables or disables the entire EJMask Spring Boot auto-configuration. Omit or set to 'enabled' to activate; set to 'disabled' to suppress all EJMask wiring.",
+      "defaultValue": "enabled"
+    },
+    {
+      "name": "ejmask.processor.content-slicer",
+      "type": "java.lang.String",
+      "description": "Enables the ContentSlicerProcessor, which truncates oversized payloads before masking to improve regex performance. Must be explicitly set to 'enabled'; absent by default.",
+      "defaultValue": "disabled"
+    },
+    {
+      "name": "ejmask.processor.content-slicer.priority",
+      "type": "java.lang.Integer",
+      "description": "Execution order of the ContentSlicerProcessor relative to other content processors. Lower values run first. Only effective when ejmask.processor.content-slicer=enabled.",
+      "defaultValue": 50
+    },
+    {
+      "name": "ejmask.processor.content-slicer.max-size",
+      "type": "java.lang.Integer",
+      "description": "Maximum content length in characters before the ContentSlicerProcessor truncates the payload. Only effective when ejmask.processor.content-slicer=enabled.",
+      "defaultValue": 10000
+    },
+    {
+      "name": "ejmask.processor.content-slicer.new-size",
+      "type": "java.lang.Integer",
+      "description": "Target content length in characters after truncation by the ContentSlicerProcessor. Must be less than ejmask.processor.content-slicer.max-size. Only effective when ejmask.processor.content-slicer=enabled.",
+      "defaultValue": 4000
+    }
+  ],
+  "hints": [
+    {
+      "name": "ejmask.autoconfig",
+      "values": [
+        {
+          "value": "enabled",
+          "description": "EJMask auto-configuration is active (default)."
+        },
+        {
+          "value": "disabled",
+          "description": "EJMask auto-configuration is suppressed entirely; no beans are registered."
+        }
+      ]
+    },
+    {
+      "name": "ejmask.processor.content-slicer",
+      "values": [
+        {
+          "value": "enabled",
+          "description": "ContentSlicerProcessor bean is created and registered as a content pre-processor."
+        },
+        {
+          "value": "disabled",
+          "description": "ContentSlicerProcessor bean is not created (default)."
+        }
+      ]
+    }
+  ]
+}

--- a/ejmask-spring/ejmask-spring-starter/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/ejmask-spring/ejmask-spring-starter/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -10,7 +10,7 @@
       "name": "ejmask.processor.content-slicer",
       "type": "java.lang.String",
       "description": "Enables the ContentSlicerProcessor, which truncates oversized payloads before masking to improve regex performance. Must be explicitly set to 'enabled'; absent by default.",
-      "defaultValue": "disabled"
+      "defaultValue": "enabled"
     },
     {
       "name": "ejmask.processor.content-slicer.priority",

--- a/ejmask-spring/pom.xml
+++ b/ejmask-spring/pom.xml
@@ -8,6 +8,7 @@
     </parent>
 
     <artifactId>ejmask-spring</artifactId>
+    <name>eJMask Spring</name>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
## Motivation
Following the Maven Central migration, deployments began failing due to a missing <name> field in the POM file.

## Proposed Changes
- Added the missing <name> field to the POM file to resolve deployment failures.
- Enhanced the documentation with detailed configuration instructions to support the updated setup.
