### PR TITLE
DEV: add PipeSeparatedValue and EscapedJson support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ For many standard use cases you can make use of pattern builders defined in the 
 | `JsonPathValuePatternBuilder`          | String       | First N chars visible; accepts full JSONPath expressions   |
 | `JsonBodyPatternBuilder`               | Object       | Fully replaces a nested JSON object with `{"****":"****"}` |
 | `JsonMiddleValuePatternBuilder`        | String       | Middle chars masked; first N/2 and last N/2 chars visible  |
+| `EscapedJsonFullValuePatternBuilder`   | String       | Fully replaced with `****`; matches escaped JSON (`\"key\":\"value\"`) |
 
 ###### JsonFieldPatternBuilder
 
@@ -202,6 +203,25 @@ EJMaskInitializer.addFilter(
 );
 ```
 
+###### EscapedJsonFullValuePatternBuilder
+
+Fully masks a JSON **string** field value inside **escaped JSON strings** — JSON encoded as a string value within another JSON document, where every quote character appears as `\"`. Use this instead of `JsonFullValuePatternBuilder` when the payload has been serialized as an escaped string. `visibleCharacters` must be `0`.
+
+```java
+// Input:  {\"cvv\":\"sensitiveData\",\"ssn\":\"123-45-6789\"}
+// Output: {\"cvv\":\"****\",\"ssn\":\"****\"}
+EJMaskInitializer.addFilter(
+    new BaseFilter(EscapedJsonFullValuePatternBuilder.class, 0, "cvv", "ssn")
+);
+
+// Also works when embedded as a value inside a regular JSON field:
+// Input:  {"body":"{\"cvv\":\"sensitiveData\",\"amount\":\"100\"}"}
+// Output: {"body":"{\"cvv\":\"****\",\"amount\":\"100\"}"}
+EJMaskInitializer.addFilter(
+    new BaseFilter(EscapedJsonFullValuePatternBuilder.class, 0, "cvv", "ssn")
+);
+```
+
 ##### Header Builder
 
 ###### HeaderFieldPatternBuilder
@@ -221,6 +241,27 @@ EJMaskInitializer.addFilter(
 // Output: Authorization=xxxx-2345
 EJMaskInitializer.addFilter(
     new BaseFilter(HeaderFieldPatternBuilder.class, 4, "Authorization")
+);
+```
+
+##### String Builders
+
+###### PipeSeparatedValuePatternBuilder
+
+Fully masks field values in **pipe-separated** `key=value` payloads, such as serialized event-pipeline data. The value delimiter is `|` or end of string. The character class also excludes `"` and `\` so that the replacement cannot bleed into adjacent JSON syntax when the payload is embedded inside a JSON field value. `visibleCharacters` is ignored; the entire value is always replaced with `****`.
+
+```java
+// Input:  userId=1234567890|payerType=SELLER|type=CHARGE
+// Output: userId=****|payerType=SELLER|type=CHARGE
+EJMaskInitializer.addFilter(
+    new BaseFilter(PipeSeparatedValuePatternBuilder.class, 0, "userId", "orgId")
+);
+
+// Also works when the payload appears as a JSON field value:
+// Input:  {"decodePayload":"userId=1234567890|payerType=SELLER|type=CHARGE"}
+// Output: {"decodePayload":"userId=****|payerType=SELLER|type=CHARGE"}
+EJMaskInitializer.addFilter(
+    new BaseFilter(PipeSeparatedValuePatternBuilder.class, 0, "userId", "orgId")
 );
 ```
 

--- a/ejmask-extensions/src/main/java/com/ebay/ejmask/extenstion/builder/json/EscapedJsonFullValuePatternBuilder.java
+++ b/ejmask-extensions/src/main/java/com/ebay/ejmask/extenstion/builder/json/EscapedJsonFullValuePatternBuilder.java
@@ -1,0 +1,73 @@
+package com.ebay.ejmask.extenstion.builder.json;
+/**
+ * Copyright (c) 2026 eBay Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.ebay.ejmask.extenstion.builder.AbstractRegexPatternBuilder;
+
+/**
+ * An implementation of {@link com.ebay.ejmask.api.IPatternBuilder} that fully masks field values
+ * inside <em>escaped</em> JSON strings — JSON that has been serialized as a string value within
+ * another JSON document, where every quote character appears as {@code \"}.
+ *
+ * <p>Unlike {@link JsonFullValuePatternBuilder}, this builder explicitly matches the backslash
+ * escape that precedes each delimiter quote, so the output remains syntactically valid after
+ * masking.
+ *
+ * <pre>
+ * Input:  {\"cvv\":\"sensitiveData\",\"amount\":\"100\"}
+ * Output: {\"cvv\":\"****\",\"amount\":\"100\"}
+ * </pre>
+ *
+ * <p>The {@code visibleCharacters} parameter is ignored; the entire value is always replaced
+ * with {@code ****}.
+ *
+ * @author fsun1
+ */
+public class EscapedJsonFullValuePatternBuilder extends AbstractRegexPatternBuilder {
+
+    // Matches: \"fieldName\":\"VALUE\"  (escaped-JSON delimiters)
+    private static final String PATTERN_TEMPLATE = "(\\\\\"(?:%s)\\\\\":\\\\\")([^\\\\\"]+)(\\\\\")";
+    // Group $1 = \"fieldName\":\"  (opening escaped delimiters, preserved)
+    // Group $2 = value             (replaced with ****)
+    // Group $3 = \"                (closing escaped delimiter, preserved)
+    private static final String REPLACEMENT = "$1****$3";
+
+    /**
+     * Builds a regex pattern that matches the named field(s) in an escaped JSON string.
+     * The {@code visibleCharacters} parameter has no effect; all characters are always masked.
+     *
+     * @param visibleCharacters ignored
+     * @param fieldNames        one or more field names to mask, combined via {@code |} alternation
+     * @return the compiled regex pattern string
+     */
+    @Override
+    public String buildPattern(int visibleCharacters, String... fieldNames) {
+        return String.format(PATTERN_TEMPLATE, super.buildFieldNamesForRegexOr(fieldNames));
+    }
+
+    /**
+     * Returns the replacement string that substitutes {@code ****} for the matched value,
+     * preserving the surrounding escaped delimiters.
+     *
+     * @param visibleCharacters ignored
+     * @param fieldNames        ignored
+     * @return the replacement string {@code $1****$3}
+     */
+    @Override
+    public String buildReplacement(int visibleCharacters, String... fieldNames) {
+        return REPLACEMENT;
+    }
+}

--- a/ejmask-extensions/src/main/java/com/ebay/ejmask/extenstion/builder/json/EscapedJsonFullValuePatternBuilder.java
+++ b/ejmask-extensions/src/main/java/com/ebay/ejmask/extenstion/builder/json/EscapedJsonFullValuePatternBuilder.java
@@ -55,6 +55,9 @@ public class EscapedJsonFullValuePatternBuilder extends AbstractRegexPatternBuil
      */
     @Override
     public String buildPattern(int visibleCharacters, String... fieldNames) {
+        if (visibleCharacters != 0) {
+            throw new IllegalArgumentException("visibleCharacters must be 0 instead of " + visibleCharacters);
+        }
         return String.format(PATTERN_TEMPLATE, super.buildFieldNamesForRegexOr(fieldNames));
     }
 

--- a/ejmask-extensions/src/main/java/com/ebay/ejmask/extenstion/builder/string/PipeSeparatedValuePatternBuilder.java
+++ b/ejmask-extensions/src/main/java/com/ebay/ejmask/extenstion/builder/string/PipeSeparatedValuePatternBuilder.java
@@ -1,0 +1,75 @@
+package com.ebay.ejmask.extenstion.builder.string;
+/**
+ * Copyright (c) 2026 eBay Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.ebay.ejmask.extenstion.builder.AbstractRegexPatternBuilder;
+
+/**
+ * An implementation of {@link com.ebay.ejmask.api.IPatternBuilder} for masking fields in
+ * pipe-separated {@code key=value} payloads, such as serialized event-pipeline data:
+ *
+ * <pre>
+ * id=123456789|type=SELLER|type=CHARGE|...
+ * </pre>
+ *
+ * <p>The value delimiter is {@code |} (or end of string). The value character class also
+ * excludes {@code "} and {@code \} so that the replacement cannot bleed into adjacent JSON
+ * syntax when the payload is embedded inside a JSON field value.
+ *
+ * <pre>
+ * Input:  id=123456789|type=SELLER
+ * Output: id=****|type=SELLER
+ * </pre>
+ *
+ * <p>The {@code visibleCharacters} parameter is ignored; the entire value is always replaced
+ * with {@code ****}.
+ *
+ * @author fsun1
+ */
+public class PipeSeparatedValuePatternBuilder extends AbstractRegexPatternBuilder {
+
+    // Stops at |, ", or \ so replacement cannot bleed into adjacent fields or JSON syntax.
+    private static final String PATTERN_TEMPLATE = "((?:%s)=)([^|\"\\\\]+)";
+    // Group $1 = fieldName=  (preserved)
+    // Group $2 = value       (replaced with ****)
+    private static final String REPLACEMENT = "$1****";
+
+    /**
+     * Builds a regex pattern that matches the named field(s) in a pipe-separated payload.
+     * The {@code visibleCharacters} parameter has no effect; all characters are always masked.
+     *
+     * @param visibleCharacters ignored
+     * @param fieldNames        one or more field names to mask, combined via {@code |} alternation
+     * @return the compiled regex pattern string
+     */
+    @Override
+    public String buildPattern(int visibleCharacters, String... fieldNames) {
+        return String.format(PATTERN_TEMPLATE, super.buildFieldNamesForRegexOr(fieldNames));
+    }
+
+    /**
+     * Returns the replacement string that substitutes {@code ****} for the matched value,
+     * preserving the leading {@code fieldName=} prefix.
+     *
+     * @param visibleCharacters ignored
+     * @param fieldNames        ignored
+     * @return the replacement string {@code $1****}
+     */
+    @Override
+    public String buildReplacement(int visibleCharacters, String... fieldNames) {
+        return REPLACEMENT;
+    }
+}

--- a/ejmask-extensions/src/test/java/com/ebay/ejmask/extenstion/builder/json/EscapedJsonFullValuePatternBuilderTest.java
+++ b/ejmask-extensions/src/test/java/com/ebay/ejmask/extenstion/builder/json/EscapedJsonFullValuePatternBuilderTest.java
@@ -1,0 +1,78 @@
+package com.ebay.ejmask.extenstion.builder.json;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+/**
+ * @author fsun1
+ */
+public class EscapedJsonFullValuePatternBuilderTest {
+
+    private static final EscapedJsonFullValuePatternBuilder instance = new EscapedJsonFullValuePatternBuilder();
+    private static final String[] fieldNames = new String[]{"cvv", "ssnLastFourDigit"};
+
+    /**
+     * Test of buildPattern method, of class EscapedJsonFullValuePatternBuilder.
+     */
+    @Test
+    public void testBuildPattern() {
+        String result = instance.buildPattern(0, fieldNames);
+        Assertions.assertEquals("(\\\\\"(?:cvv|ssnLastFourDigit)\\\\\":\\\\\")([^\\\\\"]+)(\\\\\")", result);
+    }
+
+    /**
+     * Test of buildReplacement method, of class EscapedJsonFullValuePatternBuilder.
+     */
+    @Test
+    public void testBuildReplacement() {
+        String result = instance.buildReplacement(0, fieldNames);
+        Assertions.assertEquals("$1****$3", result);
+    }
+
+    @ParameterizedTest
+    @MethodSource("dataForTestMatch")
+    public void testMatch(String name, String data, String expected) {
+        String regex = instance.buildPattern(0, fieldNames);
+        String replacement = instance.buildReplacement(0, fieldNames);
+        Pattern pattern = Pattern.compile(regex);
+        String result = pattern.matcher(data).replaceAll(replacement);
+        Assertions.assertFalse(result.contains("sensitiveData"));
+        Assertions.assertEquals(expected, result);
+    }
+
+    static Stream<Arguments> dataForTestMatch() {
+        return Stream.of(
+                Arguments.arguments(
+                        "test with escaped json - both sensitive fields masked",
+                        "{\\\"cvv\\\":\\\"sensitiveData\\\",\\\"ssnLastFourDigit\\\":\\\"sensitiveData\\\",\\\"nonSensitiveData\\\":\\\"cvv\\\"}",
+                        "{\\\"cvv\\\":\\\"****\\\",\\\"ssnLastFourDigit\\\":\\\"****\\\",\\\"nonSensitiveData\\\":\\\"cvv\\\"}"
+                ),
+                Arguments.arguments(
+                        "test with empty value - not matched, left unchanged",
+                        "{\\\"cvv\\\":\\\"\\\",\\\"other\\\":\\\"data\\\"}",
+                        "{\\\"cvv\\\":\\\"\\\",\\\"other\\\":\\\"data\\\"}"
+                ),
+                Arguments.arguments(
+                        "test with non-sensitive field not masked",
+                        "{\\\"nonSensitiveField\\\":\\\"cvv\\\"}",
+                        "{\\\"nonSensitiveField\\\":\\\"cvv\\\"}"
+                ),
+                Arguments.arguments(
+                        "test with field name appearing in value - value not masked",
+                        "{\\\"otherField\\\":\\\"cvv-value\\\",\\\"cvv\\\":\\\"sensitiveData\\\"}",
+                        "{\\\"otherField\\\":\\\"cvv-value\\\",\\\"cvv\\\":\\\"****\\\"}"
+                ),
+                Arguments.arguments(
+                        "test embedded as value inside a regular json field",
+                        "{\"body\":\"{\\\"cvv\\\":\\\"sensitiveData\\\",\\\"amount\\\":\\\"100\\\"}\"}",
+                        "{\"body\":\"{\\\"cvv\\\":\\\"****\\\",\\\"amount\\\":\\\"100\\\"}\"}"
+                )
+        );
+    }
+}

--- a/ejmask-extensions/src/test/java/com/ebay/ejmask/extenstion/builder/string/PipeSeparatedValuePatternBuilderTest.java
+++ b/ejmask-extensions/src/test/java/com/ebay/ejmask/extenstion/builder/string/PipeSeparatedValuePatternBuilderTest.java
@@ -1,0 +1,83 @@
+package com.ebay.ejmask.extenstion.builder.string;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+/**
+ * @author fsun1
+ */
+public class PipeSeparatedValuePatternBuilderTest {
+
+    private static final PipeSeparatedValuePatternBuilder instance = new PipeSeparatedValuePatternBuilder();
+    private static final String[] fieldNames = new String[]{"userId", "orgId"};
+
+    /**
+     * Test of buildPattern method, of class PipeSeparatedValuePatternBuilder.
+     */
+    @Test
+    public void testBuildPattern() {
+        String result = instance.buildPattern(0, fieldNames);
+        Assertions.assertEquals("((?:userId|orgId)=)([^|\"\\\\]+)", result);
+    }
+
+    /**
+     * Test of buildReplacement method, of class PipeSeparatedValuePatternBuilder.
+     */
+    @Test
+    public void testBuildReplacement() {
+        String result = instance.buildReplacement(0, fieldNames);
+        Assertions.assertEquals("$1****", result);
+    }
+
+    @ParameterizedTest
+    @MethodSource("dataForTestMatch")
+    public void testMatch(String name, String data, String expected) {
+        String regex = instance.buildPattern(0, fieldNames);
+        String replacement = instance.buildReplacement(0, fieldNames);
+        Pattern pattern = Pattern.compile(regex);
+        String result = pattern.matcher(data).replaceAll(replacement);
+        Assertions.assertFalse(result.contains("1234567890"));
+        Assertions.assertEquals(expected, result);
+    }
+
+    static Stream<Arguments> dataForTestMatch() {
+        return Stream.of(
+                Arguments.arguments(
+                        "test with value before pipe delimiter",
+                        "userId=1234567890|payerType=SELLER|type=CHARGE",
+                        "userId=****|payerType=SELLER|type=CHARGE"
+                ),
+                Arguments.arguments(
+                        "test with value at end of string",
+                        "type=CHARGE|userId=1234567890",
+                        "type=CHARGE|userId=****"
+                ),
+                Arguments.arguments(
+                        "test with multiple sensitive fields",
+                        "userId=1234567890|orgId=987654321|type=CHARGE",
+                        "userId=****|orgId=****|type=CHARGE"
+                ),
+                Arguments.arguments(
+                        "test does not bleed into adjacent fields",
+                        "userId=1234567890|payerType=SELLER",
+                        "userId=****|payerType=SELLER"
+                ),
+                Arguments.arguments(
+                        "test with unrelated fields not masked",
+                        "orderId=07-14661-52696|itemId=137276407571",
+                        "orderId=07-14661-52696|itemId=137276407571"
+                ),
+                Arguments.arguments(
+                        "test embedded inside a json string field value",
+                        "\"decodePayload\":\"userId=1234567890|payerType=SELLER|type=CHARGE\"",
+                        "\"decodePayload\":\"userId=****|payerType=SELLER|type=CHARGE\""
+                )
+        );
+    }
+}


### PR DESCRIPTION
##  Motivation
  
  The eBay payments (BES) accounting layer emits event payloads in two formats that EJMask could not previously mask:

  1. Escaped JSON — JSON serialized as a string value inside a containing JSON document, where every quote character appears as \". The existing JsonFullValuePatternBuilder cannot handle this because its regex does not account for the backslash before each quote delimiter.
  2. Pipe-separated key=value — a flat record format (e.g. the decodePayload field) where fields are delimited by |.

 ## Proposed Changes

  - EscapedJsonFullValuePatternBuilder (new, ejmask-extensions/builder/json): fully masks field values in escaped JSON strings.
    - \"cvv\":\"sensitiveData\" → \"cvv\":\"****\"
  - PipeSeparatedValuePatternBuilder (new, ejmask-extensions/builder/string): fully masks field values in pipe-separated payloads.
    - userId=1083849182|type=SELLER → userId=****|type=SELLER
    - Value character class excludes " and \ so replacement is safe when the payload is embedded inside a JSON string.
  - Unit tests for both builders aligned with existing project conventions (parameterized @MethodSource, exact pattern/replacement assertions).
  - README updated with usage examples and builder table entries.

 ## Test Plan
  
  - EscapedJsonFullValuePatternBuilderTest: 7 tests — normal masked, empty value (unchanged), non-sensitive field (unchanged), field name appearing in value only (unchanged), JSON-embedded payload.
  - PipeSeparatedValuePatternBuilderTest: 8 tests — value before pipe, value at end of string, multiple sensitive fields, adjacent field preserved, unrelated fields unchanged, JSON-embedded payload.
  - All 15 tests pass: mvn test -pl ejmask-extensions
